### PR TITLE
Changed BUILD.bazel to ignore gc_linkopts on MacOS

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -52,14 +52,6 @@ go_library(
 go_binary(
     name = "cip",
     embed = [":go_default_library"],
-    # These gc_linkopts make it a static binary. See
-    # https://github.com/bazelbuild/rules_go/issues/161#issuecomment-304469169.
-    gc_linkopts = [
-        "-linkmode",
-        "external",
-        "-extldflags",
-        "-static",
-    ],
     visibility = ["//visibility:public"],
 )
 


### PR DESCRIPTION
Closes: https://github.com/GoogleCloudPlatform/k8s-container-image-promoter/issues/2

Because MacOS X doesn't support static binaries:
https://github.com/bazelbuild/rules_go/issues/161#issuecomment-304469169
I made `gc_linkopts` inside cip binary configuration
present on systems which are not MacOS only.

Signed-off-by: Bart Smykla <bsmykla@vmware.com>